### PR TITLE
feat: add GitHub Pages deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,8 @@
   Run `npm i` to install the dependencies.
 
   Run `npm run dev` to start the development server.
-  
+
+  ## Deploying to GitHub Pages
+
+  Run `npm run deploy` to build the project and publish the contents of the `dist` directory to the `gh-pages` branch.
+  Make sure you have push access to the repository before running the command.

--- a/package.json
+++ b/package.json
@@ -49,13 +49,16 @@
           "tailwind-merge": "*",
           "vaul": "^1.1.2"
       },
-      "devDependencies": {
-          "@types/node": "^20.10.0",
-          "@vitejs/plugin-react-swc": "^3.10.2",
-          "vite": "6.3.5"
-      },
-      "scripts": {
-          "dev": "vite",
-          "build": "vite build"
-      }
-  }
+    "devDependencies": {
+        "@types/node": "^20.10.0",
+        "@vitejs/plugin-react-swc": "^3.10.2",
+        "vite": "6.3.5",
+        "gh-pages": "^6.1.1"
+    },
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "predeploy": "npm run build",
+        "deploy": "gh-pages -d dist"
+    }
+}


### PR DESCRIPTION
## Summary
- add gh-pages dependency and npm deploy script for publishing `dist` to GitHub Pages
- document GitHub Pages deployment steps in README

## Testing
- `npm run build`
- `npm run deploy` *(fails: gh-pages: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b565571da0832a84668ad017a017f5