### PR TITLE
Disable auto open and add deploy script

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,9 @@
+const { execSync } = require('node:child_process');
+
+try {
+  execSync('npm run build', { stdio: 'inherit' });
+  console.log('Deployment placeholder: build completed. Add hosting logic here.');
+} catch (err) {
+  console.error('Deployment failed:', err);
+  process.exit(1);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
   },
   server: {
     port: 3000,
-    open: true,
+    // Disable automatic browser opening to avoid missing xdg-open in CI
+    open: false,
   },
 });


### PR DESCRIPTION
## Summary
- avoid dev server xdg-open errors by disabling automatic browser launch
- add simple deploy script that builds the project

## Testing
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y xdg-utils` *(fails: package has no installation candidate)*
- `npm run build`
- `npm run dev`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68be9c9b8e48832aae98743022a1c5ce