### PR TITLE
Add PDF URL resolver utility

### DIFF
--- a/lib/pdfUrls.ts
+++ b/lib/pdfUrls.ts
@@ -1,0 +1,13 @@
+const pdfUrlByFileName: Record<string, string> = {
+  // Add known filename to URL mappings here.
+};
+
+export function resolvePdfUrl(fileName: string): string {
+  return (
+    pdfUrlByFileName[fileName] ??
+    new URL(
+      fileName,
+      new URL(import.meta.env.BASE_URL, window.location.origin)
+    ).href
+  );
+}


### PR DESCRIPTION
## Summary
- add resolvePdfUrl function to compute PDF URLs

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beb31a8468832a9b5a999bc569fdf4