### PR TITLE
Fix download buttons on Tariffs page

### DIFF
--- a/pages/TariffsPage.tsx
+++ b/pages/TariffsPage.tsx
@@ -2,6 +2,7 @@ import { motion } from "motion/react";
 import { Download } from "lucide-react";
 import { Button } from "../components/ui/button";
 import { toast } from "sonner@2.0.3";
+import { resolvePdfUrl } from "../lib/pdfUrls";
 
 export function TariffsPage() {
   const documents = [
@@ -9,28 +10,29 @@ export function TariffsPage() {
       title: "Структура тарифу на послуги з передачі електричної енергії",
       format: "PDF",
       size: "3.2 МБ",
-      downloadUrl: "public/docs/676443808df75689340702.pdf"
+      fileName: "docs/676443808df75689340702.pdf",
     },
     {
-      title: "Тарифи на розподіл із застосуванням стимулюючого регулювання 2025 рік",
+      title:
+        "Тарифи на розподіл із застосуванням стимулюючого регулювання 2025 рік",
       format: "PDF",
       size: "2.8 МБ",
-      downloadUrl: "public/docs/Tarifi_na_poslugi_z_rozpodilu_elektrichnoi_energii_shho_dijut_z_01.pdf"
-    }
+      fileName:
+        "docs/Tarifi_na_poslugi_z_rozpodilu_elektrichnoi_energii_shho_dijut_z_01.pdf",
+    },
   ];
 
-  const handleDownload = (document: typeof documents[0]) => {
-    // Створюємо посилання для завантаження
-    const link = document.createElement('a');
-    link.href = document.downloadUrl;
-    link.download = document.title + '.pdf';
+  const handleDownload = (doc: typeof documents[0]) => {
+    const url = resolvePdfUrl(doc.fileName);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = doc.title + ".pdf";
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
-    
-    // Показуємо повідомлення про успішне завантаження
+
     toast.success("Завантаження розпочато", {
-      description: `Документ "${document.title}" завантажується на ваш пристрій.`,
+      description: `Документ "${doc.title}" завантажується на ваш пристрій.`,
       duration: 3000,
     });
   };
@@ -41,15 +43,13 @@ export function TariffsPage() {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             {/* Заголовок та підзаголовок */}
-            <motion.div 
+            <motion.div
               className="text-center mb-16"
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8 }}
             >
-              <h1 className="text-primary mb-6">
-                ДОКУМЕНТИ ПО ТАРИФАХ
-              </h1>
+              <h1 className="text-primary mb-6">ДОКУМЕНТИ ПО ТАРИФАХ</h1>
               <p className="text-muted-foreground max-w-2xl mx-auto">
                 Завантажте офіційні документи про тарифи та методики розрахунку
               </p>
@@ -57,7 +57,7 @@ export function TariffsPage() {
 
             {/* Список документів */}
             <div className="space-y-6">
-              {documents.map((document, index) => (
+              {documents.map((doc, index) => (
                 <motion.div
                   key={index}
                   className="bg-white border border-border rounded-lg p-6 flex items-center justify-between hover:shadow-md transition-all duration-300"
@@ -70,21 +70,19 @@ export function TariffsPage() {
                     <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center flex-shrink-0">
                       <Download className="h-6 w-6 text-primary-foreground" />
                     </div>
-                    
+
                     {/* Інформація про документ */}
                     <div>
-                      <h3 className="text-primary mb-1">
-                        {document.title}
-                      </h3>
+                      <h3 className="text-primary mb-1">{doc.title}</h3>
                       <p className="text-muted-foreground">
-                        {document.format} • {document.size}
+                        {doc.format} • {doc.size}
                       </p>
                     </div>
                   </div>
 
                   {/* Кнопка завантаження */}
                   <Button
-                    onClick={() => handleDownload(document)}
+                    onClick={() => handleDownload(doc)}
                     className="bg-secondary hover:bg-secondary/90 text-secondary-foreground px-6 py-2 flex-shrink-0"
                   >
                     Завантажити
@@ -94,7 +92,7 @@ export function TariffsPage() {
             </div>
 
             {/* Додаткова інформація */}
-            <motion.div 
+            <motion.div
               className="mt-16 text-center"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
@@ -102,8 +100,9 @@ export function TariffsPage() {
             >
               <div className="bg-gray-50/50 rounded-lg p-6 max-w-2xl mx-auto">
                 <p className="text-muted-foreground">
-                  Усі документи представлені в актуальних редакціях відповідно до чинного законодавства України. 
-                  У разі виникнення питань звертайтеся до наших фахівців.
+                  Усі документи представлені в актуальних редакціях відповідно до
+                  чинного законодавства України. У разі виникнення питань
+                  звертайтеся до наших фахівців.
                 </p>
               </div>
             </motion.div>
@@ -113,3 +112,4 @@ export function TariffsPage() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- ensure Tariffs download links point to correct files and trigger downloads

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68beecc667b8832a90be3fdb4d5758fb