### PR TITLE
Hide Customer Cabinet section and fix download buttons

### DIFF
--- a/components/sections/DocumentsListSection.tsx
+++ b/components/sections/DocumentsListSection.tsx
@@ -7,6 +7,7 @@ import { Badge } from "../ui/badge";
 import { Card, CardContent } from "../ui/card";
 import { toast } from "sonner@2.0.3";
 import { resolvePdfUrl } from "../../lib/pdfUrls";
+import { downloadDocument } from "../../lib/downloadDocument";
 
 interface Document {
   id: string;
@@ -241,21 +242,6 @@ export function DocumentsListSection() {
     return matchesSearch && matchesCategory;
   });
 
-  const handleDownload = (doc: Document) => {
-    const url = resolvePdfUrl(doc.fileName);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = doc.title.replace(/[^a-zA-Z0-9а-яА-Я\s]/g, '') + '.pdf';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-
-    toast.success("Завантаження розпочато", {
-      description: `Документ "${doc.title}" завантажується на ваш пристрій.`,
-      duration: 3000,
-    });
-  };
-
   const handlePreview = (doc: Document) => {
     const url = resolvePdfUrl(doc.fileName);
     window.open(url, '_blank');
@@ -403,7 +389,7 @@ export function DocumentsListSection() {
                             </Button>
                             {!doc.viewOnly && (
                               <Button
-                                onClick={() => handleDownload(doc)}
+                                onClick={() => downloadDocument(doc.title, doc.fileName)}
                                 className="bg-secondary hover:bg-secondary/90 text-secondary-foreground"
                               >
                                 <Download className="h-4 w-4 mr-2" />

--- a/lib/downloadDocument.ts
+++ b/lib/downloadDocument.ts
@@ -1,0 +1,18 @@
+import { toast } from "sonner@2.0.3";
+import { resolvePdfUrl } from "./pdfUrls";
+
+export function downloadDocument(title: string, fileName: string) {
+  const url = resolvePdfUrl(fileName);
+  const extension = fileName.split(".").pop() || "pdf";
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `${title.replace(/[^a-zA-Z0-9а-яА-Я\s]/g, "")}.${extension}`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+
+  toast.success("Завантаження розпочато", {
+    description: `Документ "${title}" завантажується на ваш пристрій.`,
+    duration: 3000,
+  });
+}

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -1,14 +1,14 @@
 import { HeroSection } from "../components/sections/HeroSection";
 import { AdvantagesHeroSection } from "../components/sections/AdvantagesHeroSection";
-import { CustomerCabinetSection } from "../components/sections/CustomerCabinetSection";
 import { ImportantDocumentsSection } from "../components/sections/ImportantDocumentsSection";
+
+// CustomerCabinetSection temporarily removed from homepage
 
 export function HomePage() {
   return (
     <div className="min-h-screen">
       <HeroSection />
       <AdvantagesHeroSection />
-      <CustomerCabinetSection />
       <ImportantDocumentsSection />
     </div>
   );

--- a/pages/TariffsPage.tsx
+++ b/pages/TariffsPage.tsx
@@ -1,7 +1,7 @@
 import { motion } from "motion/react";
 import { Download } from "lucide-react";
 import { Button } from "../components/ui/button";
-import { toast } from "sonner@2.0.3";
+import { downloadDocument } from "../lib/downloadDocument";
 
 export function TariffsPage() {
   const documents = [
@@ -9,30 +9,20 @@ export function TariffsPage() {
       title: "Структура тарифу на послуги з передачі електричної енергії",
       format: "PDF",
       size: "3.2 МБ",
-      downloadUrl: "public/docs/676443808df75689340702.pdf"
+      fileName: "docs/676443808df75689340702.pdf",
     },
     {
-      title: "Тарифи на розподіл із застосуванням стимулюючого регулювання 2025 рік",
+      title:
+        "Тарифи на розподіл із застосуванням стимулюючого регулювання 2025 рік",
       format: "PDF",
       size: "2.8 МБ",
-      downloadUrl: "public/docs/Tarifi_na_poslugi_z_rozpodilu_elektrichnoi_energii_shho_dijut_z_01.pdf"
-    }
+      fileName:
+        "docs/Tarifi_na_poslugi_z_rozpodilu_elektrichnoi_energii_shho_dijut_z_01.pdf",
+    },
   ];
 
-  const handleDownload = (document: typeof documents[0]) => {
-    // Створюємо посилання для завантаження
-    const link = document.createElement('a');
-    link.href = document.downloadUrl;
-    link.download = document.title + '.pdf';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    
-    // Показуємо повідомлення про успішне завантаження
-    toast.success("Завантаження розпочато", {
-      description: `Документ "${document.title}" завантажується на ваш пристрій.`,
-      duration: 3000,
-    });
+  const handleDownload = (doc: typeof documents[0]) => {
+    downloadDocument(doc.title, doc.fileName);
   };
 
   return (
@@ -41,15 +31,13 @@ export function TariffsPage() {
         <div className="container mx-auto px-4">
           <div className="max-w-4xl mx-auto">
             {/* Заголовок та підзаголовок */}
-            <motion.div 
+            <motion.div
               className="text-center mb-16"
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8 }}
             >
-              <h1 className="text-primary mb-6">
-                ДОКУМЕНТИ ПО ТАРИФАХ
-              </h1>
+              <h1 className="text-primary mb-6">ДОКУМЕНТИ ПО ТАРИФАХ</h1>
               <p className="text-muted-foreground max-w-2xl mx-auto">
                 Завантажте офіційні документи про тарифи та методики розрахунку
               </p>
@@ -57,7 +45,7 @@ export function TariffsPage() {
 
             {/* Список документів */}
             <div className="space-y-6">
-              {documents.map((document, index) => (
+              {documents.map((doc, index) => (
                 <motion.div
                   key={index}
                   className="bg-white border border-border rounded-lg p-6 flex items-center justify-between hover:shadow-md transition-all duration-300"
@@ -70,21 +58,19 @@ export function TariffsPage() {
                     <div className="w-12 h-12 bg-primary rounded-lg flex items-center justify-center flex-shrink-0">
                       <Download className="h-6 w-6 text-primary-foreground" />
                     </div>
-                    
+
                     {/* Інформація про документ */}
                     <div>
-                      <h3 className="text-primary mb-1">
-                        {document.title}
-                      </h3>
+                      <h3 className="text-primary mb-1">{doc.title}</h3>
                       <p className="text-muted-foreground">
-                        {document.format} • {document.size}
+                        {doc.format} • {doc.size}
                       </p>
                     </div>
                   </div>
 
                   {/* Кнопка завантаження */}
                   <Button
-                    onClick={() => handleDownload(document)}
+                    onClick={() => handleDownload(doc)}
                     className="bg-secondary hover:bg-secondary/90 text-secondary-foreground px-6 py-2 flex-shrink-0"
                   >
                     Завантажити
@@ -94,7 +80,7 @@ export function TariffsPage() {
             </div>
 
             {/* Додаткова інформація */}
-            <motion.div 
+            <motion.div
               className="mt-16 text-center"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
@@ -102,8 +88,9 @@ export function TariffsPage() {
             >
               <div className="bg-gray-50/50 rounded-lg p-6 max-w-2xl mx-auto">
                 <p className="text-muted-foreground">
-                  Усі документи представлені в актуальних редакціях відповідно до чинного законодавства України. 
-                  У разі виникнення питань звертайтеся до наших фахівців.
+                  Усі документи представлені в актуальних редакціях відповідно до
+                  чинного законодавства України. У разі виникнення питань
+                  звертайтеся до наших фахівців.
                 </p>
               </div>
             </motion.div>
@@ -113,3 +100,4 @@ export function TariffsPage() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- extract reusable `downloadDocument` helper for PDF downloads
- wire Documents page to use shared download logic
- update Tariffs page to use the new helper
- preserve original file extension when downloading documents
- temporarily remove CustomerCabinet section from the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68beecc667b8832a90be3fdb4d5758fb