### PR TITLE
Fix runtime blank page by adding ThemeProvider

### DIFF
--- a/components/CustomerCabinetModal.tsx
+++ b/components/CustomerCabinetModal.tsx
@@ -8,7 +8,7 @@ import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
 import { Checkbox } from "./ui/checkbox";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { X, User, Lock, Zap, ChevronLeft, ChevronRight } from "lucide-react";
-import { toast } from "sonner@2.0.3";
+import { toast } from "sonner";
 
 interface CustomerCabinetModalProps {
   isOpen: boolean;

--- a/main.tsx
+++ b/main.tsx
@@ -1,7 +1,12 @@
 
-  import { createRoot } from "react-dom/client";
-  import App from "./App.tsx";
-  import "./index.css";
+import { createRoot } from "react-dom/client";
+import { ThemeProvider } from "next-themes";
+import App from "./App.tsx";
+import "./index.css";
 
-  createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <App />
+  </ThemeProvider>
+);
   

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import { HeroSection } from "../components/sections/HeroSection";
 import { AdvantagesHeroSection } from "../components/sections/AdvantagesHeroSection";
 import { ImportantDocumentsSection } from "../components/sections/ImportantDocumentsSection";
+import { CustomerCabinetSection } from "../components/sections/CustomerCabinetSection";
 
 export function HomePage() {
   return (


### PR DESCRIPTION
## Summary
- wrap React root with `ThemeProvider` so `useTheme` from `next-themes` has context

## Testing
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68c020398894832ab56e97311f9e1d91