### PR TITLE
fix: configure router basename for subpath deployment

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,8 +10,9 @@ import { ContactPage } from "./pages/ContactPage";
 import { Toaster } from "./components/ui/sonner";
 
 export default function App() {
+  const basename = import.meta.env.BASE_URL.replace(/^\./, "");
   return (
-    <Router basename="/">
+    <Router basename={basename}>
       <div className="min-h-screen bg-background">
         <Header />
         <main>


### PR DESCRIPTION
## Summary
- handle deployment to subpaths by deriving router basename from Vite base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c179e8133c832a887b1151b5671dc0