### PR TITLE
fix: normalize router basename for root deployments

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,12 +10,16 @@ import { ContactPage } from "./pages/ContactPage";
 import { Toaster } from "./components/ui/sonner";
 
 export default function App() {
+<<<<<<< codex/deploy-site-with-fix_10_09_2025-branch-bbd5s7
   // Derive router basename from Vite's base URL, removing leading dots and
   // trailing slashes. When the app is served from the root ("/"), fallback to
   // an empty basename so routes resolve correctly instead of "//".
   const rawBase = import.meta.env.BASE_URL;
   const basename = rawBase === "/" ? "" : rawBase.replace(/^\./, "").replace(/\/$/, "");
 
+=======
+  const basename = import.meta.env.BASE_URL.replace(/^\./, "");
+>>>>>>> main
   return (
     <Router basename={basename}>
       <div className="min-h-screen bg-background">


### PR DESCRIPTION
## Summary
- normalize router basename derived from Vite base to avoid double leading slashes and support root deployments

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c179e8133c832a887b1151b5671dc0