### PR TITLE
fix: derive router basename from base URL

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,8 +10,14 @@ import { ContactPage } from "./pages/ContactPage";
 import { Toaster } from "./components/ui/sonner";
 
 export default function App() {
+  // Derive router basename from Vite's base URL, removing leading dots and
+  // trailing slashes. When served from the root ("/"), use an empty basename so
+  // routes resolve correctly without double slashes.
+  const rawBase = import.meta.env.BASE_URL;
+  const basename = rawBase === "/" ? "" : rawBase.replace(/^\./, "").replace(/\/$/, "");
+
   return (
-    <Router basename="/">
+    <Router basename={basename}>
       <div className="min-h-screen bg-background">
         <Header />
         <main>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
     <body>
       <div id="root"></div>
-      <script type="module" src="/main.tsx"></script>
+      <script type="module" src="./main.tsx"></script>
     </body>
   </html>
   


### PR DESCRIPTION
## Summary
- derive Router basename from Vite's BASE_URL, stripping dots and trailing slashes
- use the computed basename with BrowserRouter for reliable static hosting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68c179e8133c832a887b1151b5671dc0