### PR TITLE
fix: remove custom router basename

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,9 +10,8 @@ import { ContactPage } from "./pages/ContactPage";
 import { Toaster } from "./components/ui/sonner";
 
 export default function App() {
-  const basename = import.meta.env.BASE_URL.replace(/^\./, "");
   return (
-    <Router basename={basename}>
+    <Router>
       <div className="min-h-screen bg-background">
         <Header />
         <main>


### PR DESCRIPTION
## Summary
- remove custom `basename` logic from the hash router to avoid incorrect routing

## Testing
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68c19c41eee4832aa922f284d1dcba38