### PR TITLE
fix: use browser router with absolute base

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import { HashRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import { Header } from "./components/Header";
 import { Footer } from "./components/Footer";
 import { HomePage } from "./pages/HomePage";
@@ -10,9 +10,8 @@ import { ContactPage } from "./pages/ContactPage";
 import { Toaster } from "./components/ui/sonner";
 
 export default function App() {
-  const basename = import.meta.env.BASE_URL.replace(/^\./, "");
   return (
-    <Router basename={basename}>
+    <Router>
       <div className="min-h-screen bg-background">
         <Header />
         <main>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,8 +4,8 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
-  // Use root base path so the site works on a custom domain
-  base: './',
+  // Use an absolute base path so the site works on a custom domain
+  base: '/',
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
     alias: {


### PR DESCRIPTION
## Summary
- drop custom router `basename` so BrowserRouter uses the root path from Vite

## Testing
- `npm run build`
- `npm run deploy`


------
https://chatgpt.com/codex/tasks/task_e_68c19c41eee4832aa922f284d1dcba38