### PR TITLE
Use relative base path for static deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,18 @@
 
   Run `npm i` to install the dependencies.
 
-  Run `npm run dev` to start the development server.
+Run `npm run dev` to start the development server.
+
+## Building for production
+
+Run `npm run build` to generate a static version of the site in the `dist/` directory. Serve the files from this folder with any static file server:
+
+```
+npm run build
+npx vite preview
+```
+
+Opening `dist/index.html` directly or deploying the `dist/` directory ensures all modules are served with the correct MIME type and prevents the "Failed to load module script" error.
 
   ## Deploying to GitHub Pages
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  // Use a relative base path so the app works when served from a subdirectory
+  base: './',
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
     alias: {


### PR DESCRIPTION
## Summary
- configure Vite with a relative `base` path so assets resolve properly when served from a subdirectory
- document production build steps and note that serving `dist/` avoids MIME errors for module scripts

## Testing
- `npm run build`
- `npx vite preview --port 4175` and `curl -I http://localhost:4175/`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc904b08832ab3ee5db804a20aae