### PR TITLE
Configure relative base and preview port for static deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,21 @@
 
   Run `npm i` to install the dependencies.
 
-  Run `npm run dev` to start the development server.
+Run `npm run dev` to start the development server.
 
-  ## Deploying to GitHub Pages
+## Building for production
 
-  Run `npm run deploy` to build the project and publish the contents of the `dist` directory to the `gh-pages` branch.
-  Make sure you have push access to the repository before running the command.
+ Run `npm run build` to generate a static version of the site in the `dist/` directory. Then preview the result on the same port as the dev server:
+
+```
+npm run build
+npm run preview
+```
+
+The preview script serves `dist/` on `http://localhost:3000`. Vite uses ports in the `4173` range by default, but pinning the preview to `3000` avoids confusion and matches the development server.
+
+Opening `dist/index.html` directly or deploying the `dist/` directory ensures all modules are served with the correct MIME type and prevents the "Failed to load module script" error.
+
+  ## Deployment
+
+  `npm run deploy` currently builds the project and prints a reminder to add hosting logic. After running the script, upload the contents of `dist/` to your hosting provider (e.g. GitHub Pages, Netlify, Vercel).

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "preview": "vite preview --port 3000",
     "deploy": "node scripts/deploy.js"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@ import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
-  base: '/',
+  // Use a relative base path so the app works when served from a subdirectory
+  base: './',
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
     alias: {


### PR DESCRIPTION
## Summary
- configure Vite with a relative `base` path so assets resolve properly from subdirectories
- document production build steps and preview the build on the same port as the dev server (3000)
- add an npm `preview` script pinned to port 3000 for consistent testing

## Testing
- `npm run build`
- `npm run preview`
- `curl -I http://localhost:3000/`


------
https://chatgpt.com/codex/tasks/task_e_68c1bc904b08832ab3ee5db804a20aae